### PR TITLE
fix: separate and document unmock

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ mock
 
   Usage
     $ mock <command> <argument> [exit code] [executed code]
+    $ unmock <command>
 
   Arguments
     command        The command you would like to have mocked
@@ -37,7 +38,8 @@ $ mock
   Examples
     $ mock git pull 0 "echo This command successfully echoes"
     $ mock git push 1 "echo This command fails with status 1"
-    $ mock git \* 0 "echo This command acts as a fallback to all git commands"
+    $ mock git \*   0 "echo This command acts as a fallback to all git commands"
+    $ unmock git      # Original git functionality is now restored
 
   Tips
     To view this manual, use the mock command without providing arguments.

--- a/functions/mock.fish
+++ b/functions/mock.fish
@@ -1,4 +1,4 @@
-function mock -a cmd -a argument -a exit_code -a executed_code -d "Quick and powerful fish shell mocks"
+function mock -a cmd -a argument -a exit_code -a executed_code -d "Mock a command"
   set -l cmd_blacklist "[" and argparse begin break builtin case command continue else end eval exec for function functions if not or read return set status switch test while
 
   if test (count $argv) -lt 1
@@ -70,14 +70,5 @@ Tips
     else
       eval command $cmd $argv
     end
-  end
-
-  function unmock -a cmd
-    functions -e $cmd
-    set -l mocked_args "_mocked_"$cmd"_args"
-    functions -e "mocked_"$cmd"_fn_"{$$mocked_args}
-    set -e $mocked_args
-    set _mocked (string match -v $cmd $_mocked)
-    return 0
   end
 end

--- a/functions/mock.fish
+++ b/functions/mock.fish
@@ -5,6 +5,7 @@ function mock -a cmd -a argument -a exit_code -a executed_code -d "Mock a comman
     echo "
 Usage
   \$ mock <command> <argument> [exit code] [executed code]
+  \$ unmock <command>
 
 Arguments
   command        The command you would like to have mocked
@@ -15,7 +16,8 @@ Arguments
 Examples
   \$ mock git pull 0 \"echo This command successfully echoes\"
   \$ mock git push 1 \"echo This command fails with status 1\"
-  \$ mock git \* 0 \"echo This command acts as a fallback to all git commands\"
+  \$ mock git \*   0 \"echo This command acts as a fallback to all git commands\"
+  \$ unmock git      # Original git functionality is now restored
 
 Tips
   To view this manual, use the mock command without providing arguments.

--- a/functions/unmock.fish
+++ b/functions/unmock.fish
@@ -8,8 +8,9 @@ Arguments
   command        The command you would like to unmock
 
 Examples
-  \$ unmock git  # The original git command can now be used
+  \$ unmock git   # The original git command can now be used
 "
+    return 0
   end
 
   functions -e $cmd

--- a/functions/unmock.fish
+++ b/functions/unmock.fish
@@ -1,0 +1,21 @@
+function unmock -a cmd -d "Destroy an existing mock"
+  if test (count $argv) -lt 1
+      echo "
+Usage
+  \$ unmock <command>
+
+Arguments
+  command        The command you would like to unmock
+
+Examples
+  \$ unmock git  # The original git command can now be used
+"
+  end
+
+  functions -e $cmd
+  set -l mocked_args "_mocked_"$cmd"_args"
+  functions -e "mocked_"$cmd"_fn_"{$$mocked_args}
+  set -e $mocked_args
+  set _mocked (string match -v $cmd $_mocked)
+  return 0
+end

--- a/tests/mock.fish
+++ b/tests/mock.fish
@@ -1,92 +1,84 @@
 function setup
   set root (dirname (status -f))
-  source $root/mock.fish
+  source $root/functions/mock.fish
 end
 
-test "$TESTNAME It should be able to mock with exit success"
+test "$TESTNAME - It should be able to mock with exit success"
   (mock ls \*; and ls) $status -eq 0
 end
 
-test "$TESTNAME It should be able to non-wildcard mock with exit success"
+test "$TESTNAME - It should be able to non-wildcard mock with exit success"
   (mock ls a; and ls a) $status -eq 0
 end
 
-test "$TESTNAME It should be able to mock with fail status"
+test "$TESTNAME - It should be able to mock with fail status"
    (mock ls \* 1; and ls) $status -eq 1
 end
 
-test "$TESTNAME It should be able to non-wildcard mock with fail status"
+test "$TESTNAME - It should be able to non-wildcard mock with fail status"
    (mock ls a 1; and ls a) $status -eq 1
 end
 
-test "$TESTNAME It should be able to mock with function body"
+test "$TESTNAME - It should be able to mock with function body"
    hello = (mock ls \* 0 "echo hello"; and ls )
 end
 
-test "$TESTNAME It should be able to non-wildcard mock with function body"
+test "$TESTNAME - It should be able to non-wildcard mock with function body"
    hello = (mock ls a 0 "echo hello"; and ls a )
 end
 
-test "$TESTNAME It should be able to use argument"
+test "$TESTNAME - It should be able to use argument"
    "hello joe" = (mock ls \* 0 "echo hello \$args"; and ls joe )
 end
 
-test "$TESTNAME It should be able to use argument in non-wildcard mock"
+test "$TESTNAME - It should be able to use argument in non-wildcard mock"
    "hello joe" = (mock ls a 0 "echo hello \$args"; and ls a joe )
 end
 
-test "$TESTNAME It should be able to use some arguments"
+test "$TESTNAME - It should be able to use some arguments"
    "hello joe" = (mock ls \* 0 "echo hello \$args[1]"; and ls joe mike )
 end
 
-test "$TESTNAME It should be able to use some arguments in non-wildcard mock"
+test "$TESTNAME - It should be able to use some arguments in non-wildcard mock"
    "hello joe" = (mock ls a 0 "echo hello \$args[1]"; and ls a joe mike )
 end
 
-test "$TESTNAME It should be able to use multiple arguments"
+test "$TESTNAME - It should be able to use multiple arguments"
    "hello joe and mike" = (mock ls \* 0 "echo hello \$args[1] and \$args[2]"; and ls joe mike )
 end
 
-test "$TESTNAME It should be able to use multiple arguments in non-wildcard mock"
+test "$TESTNAME - It should be able to use multiple arguments in non-wildcard mock"
    "hello joe and mike" = (mock ls a 0 "echo hello \$args[1] and \$args[2]"; and ls a joe mike )
 end
 
-test "$TESTNAME It should be able to use nested functions"
+test "$TESTNAME - It should be able to use nested functions"
    "1 2 3 4 5" = (mock ls \* 0 "echo (seq 5)"; and ls )
 end
 
-test "$TESTNAME It should be able to use nested functions in non-wildcard mock"
+test "$TESTNAME - It should be able to use nested functions in non-wildcard mock"
    "1 2 3 4 5" = (mock ls a 0 "echo (seq 5)"; and ls a )
 end
 
-test "$TESTNAME It should be able to use nested functions with arguments"
+test "$TESTNAME - It should be able to use nested functions with arguments"
    "1 2 3 4 5" = (mock ls \* 0 "echo (seq \$args)"; and ls 5)
 end
 
-test "$TESTNAME It should be able to use nested functions in non-wildcard mock with arguments"
+test "$TESTNAME - It should be able to use nested functions in non-wildcard mock with arguments"
    "1 2 3 4 5" = (mock ls a 0 "echo (seq \$args)"; and ls a 5)
 end
 
-test "$TESTNAME It should not mock blacklisted elements 1"
+test "$TESTNAME - It should not mock blacklisted elements 1"
    (mock builtin \*) = "The function \"builtin\" is reserved and therefore cannot be mocked." -a $status -eq 1
 end
 
-test "$TESTNAME It should not mock blacklisted elements 2"
+test "$TESTNAME - It should not mock blacklisted elements 2"
    (mock functions \*) = "The function \"functions\" is reserved and therefore cannot be mocked." -a $status -eq 1
 end
 
-test "$TESTNAME It should not mock blacklisted elements 3"
+test "$TESTNAME - It should not mock blacklisted elements 3"
    (mock eval \*) = "The function \"eval\" is reserved and therefore cannot be mocked." -a $status -eq 1
 end
 
-test "$TESTNAME It should not mock blacklisted elements 4"
+test "$TESTNAME - It should not mock blacklisted elements 4"
    (mock "[" \*) = "The function \"[\" is reserved and therefore cannot be mocked." -a $status -eq 1
-end
-
-test "$TESTNAME Unmock previously created mock"
-   "hello joe" = (mock echo \* 0 "echo fail"; and unmock echo; and echo "hello joe")
-end
-
-test "$TESTNAME Unmock previously created mock with non-wildcard"
-   "hi" = (mock echo hi 0 "echo fail"; and unmock echo; and echo hi)
 end

--- a/tests/mock.fish
+++ b/tests/mock.fish
@@ -87,6 +87,6 @@ test "$TESTNAME Unmock previously created mock"
    "hello joe" = (mock echo \* 0 "echo fail"; and unmock echo; and echo "hello joe")
 end
 
-test "$TESTNAME Unmock previously created mock with non-wildstar"
+test "$TESTNAME Unmock previously created mock with non-wildcard"
    "hi" = (mock echo hi 0 "echo fail"; and unmock echo; and echo hi)
 end

--- a/tests/unmock.fish
+++ b/tests/unmock.fish
@@ -1,0 +1,13 @@
+function setup
+  set root (dirname (status -f))
+  source $root/functions/mock.fish
+  source $root/functions/unmock.fish
+end
+
+test "$TESTNAME - It should unmock a previously created mock"
+   "hello joe" = (mock echo \* 0 "echo fail"; and unmock echo; and echo "hello joe")
+end
+
+test "$TESTNAME - It should unmock a previously created mock with non-wildcard"
+   "hi" = (mock echo hi 0 "echo fail"; and unmock echo; and echo hi)
+end


### PR DESCRIPTION
As suggested in [this conversation](https://github.com/jorgebucaran/awesome-fish/pull/54), unmock should be documented and separated so that the function is not recreated every time `mock` is run.